### PR TITLE
Fixed invalid texture names

### DIFF
--- a/sketchup_importer/__init__.py
+++ b/sketchup_importer/__init__.py
@@ -337,7 +337,11 @@ class SceneImporter():
                 default_shader_alpha.default_value = round((a / 255.0), 2)
 
                 if tex:
-                    tex_name = tex.name.split("\\")[-1]
+                    if tex.name[0] == '.' and len(tex.name) < 5:
+                        #Combine material name with image extension for a valid name
+                        tex_name = mat.name + tex.name
+                    else:
+                        tex_name = tex.name.split("\\")[-1]
                     tmp_name = os.path.join(tempfile.gettempdir(), tex_name)
                     # skp_log(f"Texture saved temporarily at {tmp_name}")
                     tex.write(tmp_name)


### PR DESCRIPTION
The sketchup api doesn't ensure there is a valid filename in texture.name, sometimes it only contains the filename extension.

Blender handles this fine, except when such materials are exported to other formats like fbx, then the missing filenames creates trouble.

I've solved this issue by checking if the texture.name starts with a '.' and the length is less than 5 characters. In this case we know that there will only be an image extension in the filename, and should combine it with the material name.

This simple fix ensures you can export the imported model.